### PR TITLE
Docker勉強会vol.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 services:
-  frontend:
+  docker-study-frontend:
     container_name: frontend
     build:
       context: .
@@ -8,14 +8,14 @@ services:
      - 3000:3000
     volumes:
       - ./packages/service-frontend/node_modules:/app/node_modules
-  backend:
+  docker-study-backend:
     container_name: backend
     build:
       context: .
       dockerfile: ./packages/service-backend/DockerFile
     ports: 
      - 4000:4000
-  server:
+  docker-study-server:
     container_name: server
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,3 +15,12 @@ services:
       dockerfile: ./packages/service-backend/DockerFile
     ports: 
      - 4000:4000
+  server:
+    container_name: server
+    build:
+      context: .
+      dockerfile: ./packages/service-server/DockerFile
+    ports: 
+     - 80:80  
+    volumes:
+       - ./packages/service-server/nginx.conf:/etc/nginx/nginx.conf

--- a/packages/service-backend/main.go
+++ b/packages/service-backend/main.go
@@ -7,8 +7,11 @@ import (
 	"os"
 )
 
-func setupHeader(response http.ResponseWriter) {
-	response.Header().Set("Access-Control-Allow-Origin", "http://localhost:3000")
+func setupHeader(response http.ResponseWriter, request *http.Request) {
+	origin := request.Header.Get("Origin")
+	if origin == "http://localhost" || origin == "http://localhost:3000" {
+		response.Header().Set("Access-Control-Allow-Origin", origin)
+	}
 	response.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE")
 	response.Header().Set("Access-Control-Allow-Headers", "application/json")
 }
@@ -16,7 +19,7 @@ func setupHeader(response http.ResponseWriter) {
 type SampleHandler struct{}
 
 func (h *SampleHandler) ServeHTTP(response http.ResponseWriter, request *http.Request) {
-	setupHeader(response)
+	setupHeader(response, request)
 	var sampleData = map[string]string{
 		"message": "Hello, World!",
 	}

--- a/packages/service-frontend/src/App.vue
+++ b/packages/service-frontend/src/App.vue
@@ -4,7 +4,7 @@
 
   const fetchData = async () => {
     try {
-      const response = await axios.get('http://localhost:4000/sample')
+      const response = await axios.get('http://localhost/api/sample')
       return response.data
     } catch (error) {
       console.error(error)

--- a/packages/service-server/DockerFile
+++ b/packages/service-server/DockerFile
@@ -1,0 +1,4 @@
+FROM nginx:1.19-alpine
+COPY packages/service-server/nginx.conf /etc/nginx/nginx.conf 
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/packages/service-server/nginx.conf
+++ b/packages/service-server/nginx.conf
@@ -1,0 +1,17 @@
+events {
+  worker_connections 1024;
+}
+http {
+  server {
+    listen 80;
+    server_name localhost;
+    location / {
+      proxy_pass http://frontend:3000;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection 'upgrade';
+      proxy_set_header Host $host;
+      proxy_cache_bypass $http_upgrade;
+    }
+  }
+}

--- a/packages/service-server/nginx.conf
+++ b/packages/service-server/nginx.conf
@@ -13,5 +13,14 @@ http {
       proxy_set_header Host $host;
       proxy_cache_bypass $http_upgrade;
     }
+    
+    location /api/ {
+      proxy_pass http://backend:4000/;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection 'upgrade';
+      proxy_set_header Host $host;
+      proxy_cache_bypass $http_upgrade;
+    }
   }
 }

--- a/packages/service-server/nginx.conf
+++ b/packages/service-server/nginx.conf
@@ -8,19 +8,13 @@ http {
     location / {
       proxy_pass http://frontend:3000;
       proxy_http_version 1.1;
-      proxy_set_header Upgrade $http_upgrade;
-      proxy_set_header Connection 'upgrade';
       proxy_set_header Host $host;
-      proxy_cache_bypass $http_upgrade;
     }
     
     location /api/ {
       proxy_pass http://backend:4000/;
       proxy_http_version 1.1;
-      proxy_set_header Upgrade $http_upgrade;
-      proxy_set_header Connection 'upgrade';
       proxy_set_header Host $host;
-      proxy_cache_bypass $http_upgrade;
     }
   }
 }


### PR DESCRIPTION
## 変更項目
- `nginx`のDockerイメージ作成
- `nginx.conf` を作成し `:3000` と `:4000` ポートのproxyを設定
- `docker-compose.yml` の更新
- `backend`のcors設定を更新
- `frontend` から叩くAPIのエンドポイントを変更